### PR TITLE
Add optional TwelveLabs Pegasus transcription engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ You can easily select custom models, languages, and tasks, fine-tune transcripti
 👥 Speaker identification<br>
 🌍 Supports all languages supported by the Whisper model (+30)<br>
 🎮 User-friendly GUI interface<br>
+☁️ Optional cloud transcription via the TwelveLabs Pegasus model<br>
+
+## Transcription engines
+
+SoftWhisper supports two transcription engines, selectable from the **Engine**
+dropdown in *Optional Settings*:
+
+- **whisper.cpp** (default) — runs locally using the bundled Whisper.cpp model.
+  No account or network required.
+- **twelvelabs-pegasus** — runs in the cloud using the TwelveLabs Pegasus
+  video-understanding model. This is fully opt-in and never changes the default
+  behavior.
+
+To use the TwelveLabs engine, set a `TWELVELABS_API_KEY` environment variable
+(or paste a key into the *TwelveLabs API Key* field) and select
+`twelvelabs-pegasus` from the Engine dropdown. You can grab a free API key at
+https://twelvelabs.io — there's a generous free tier.
 
 ## Usage
 

--- a/SoftWhisper.py
+++ b/SoftWhisper.py
@@ -76,6 +76,16 @@ def set_console_redirect(console_queue):
 def transcribe_audio(file_path, options, progress_callback=None, status_callback=None, stop_event=None):
     file_path = os.path.abspath(file_path)
     debug_print(f"transcribe_audio() => Processing file: {file_path}")
+
+    # Opt-in cloud backend: route to TwelveLabs Pegasus when selected. The
+    # default ('whisper.cpp') path below is unchanged.
+    if options.get('engine') == 'twelvelabs-pegasus':
+        from twelvelabs_backend import transcribe_with_pegasus
+        debug_print("Using TwelveLabs Pegasus transcription backend.")
+        return transcribe_with_pegasus(
+            file_path, options, progress_callback, status_callback, stop_event
+        )
+
     model_name = options.get('model_name', 'base')
     model_path = os.path.abspath(os.path.join("models", "whisper", f"ggml-{model_name}.bin"))
     language = options.get('language', 'auto')
@@ -280,6 +290,10 @@ class SoftWhisper:
         self.previous_model = "base"
         self.model_var = tk.StringVar(value="base")
         self.task_var = tk.StringVar(value="transcribe")
+        # Transcription engine: "whisper.cpp" (default, local) or
+        # "twelvelabs-pegasus" (opt-in cloud backend).
+        self.engine_var = tk.StringVar(value="whisper.cpp")
+        self.twelvelabs_api_key_var = tk.StringVar(value=os.environ.get("TWELVELABS_API_KEY", ""))
         self.language_var = tk.StringVar(value="auto")
         self.beam_size_var = tk.IntVar(value=5)
         self.start_time_var = tk.StringVar(value="00:00:00")
@@ -397,67 +411,83 @@ class SoftWhisper:
         settings_frame = tk.LabelFrame(right_frame, text="Optional Settings", padx=10, pady=10, font=("Arial", 12))
         settings_frame.pack(padx=10, pady=10, fill="x")
 
-        # Row 0: Model
-        tk.Label(settings_frame, text="Model:", font=("Arial", 10)).grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        # Row 0: Engine (transcription backend)
+        tk.Label(settings_frame, text="Engine:", font=("Arial", 10)).grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        engine_options = ["whisper.cpp", "twelvelabs-pegasus"]
+        self.engine_menu = ttk.Combobox(settings_frame, textvariable=self.engine_var, values=engine_options,
+                                        state="readonly", width=20, font=("Arial", 10))
+        self.engine_menu.grid(row=0, column=1, sticky="w", padx=5, pady=5)
+        self.engine_menu.bind("<<ComboboxSelected>>", self.on_engine_change)
+
+        # Row 1: Model
+        tk.Label(settings_frame, text="Model:", font=("Arial", 10)).grid(row=1, column=0, sticky="w", padx=5, pady=5)
         model_options = ["tiny", "tiny.en", "base", "base.en", "small", "small.en",
                          "medium", "medium.en", "large", "large-v2", "large-v3", "large-v3-turbo"]
         self.model_menu = ttk.Combobox(settings_frame, textvariable=self.model_var, values=model_options,
                                        state="readonly", width=20, font=("Arial", 10))
-        self.model_menu.grid(row=0, column=1, sticky="w", padx=5, pady=5)
+        self.model_menu.grid(row=1, column=1, sticky="w", padx=5, pady=5)
         self.model_menu.bind("<<ComboboxSelected>>", self.on_model_change)
 
-        # Row 1: Task
-        tk.Label(settings_frame, text="Task:", font=("Arial", 10)).grid(row=1, column=0, sticky="w", padx=5, pady=5)
+        # Row 2: Task
+        tk.Label(settings_frame, text="Task:", font=("Arial", 10)).grid(row=2, column=0, sticky="w", padx=5, pady=5)
         task_options = ["transcribe", "translate"]
         self.task_menu = ttk.Combobox(settings_frame, textvariable=self.task_var, values=task_options,
                                       state="readonly", width=20, font=("Arial", 10))
-        self.task_menu.grid(row=1, column=1, sticky="w", padx=5, pady=5)
+        self.task_menu.grid(row=2, column=1, sticky="w", padx=5, pady=5)
 
-        # Row 2: Language
-        tk.Label(settings_frame, text="Language:", font=("Arial", 10)).grid(row=2, column=0, sticky="w", padx=5, pady=5)
+        # Row 3: Language
+        tk.Label(settings_frame, text="Language:", font=("Arial", 10)).grid(row=3, column=0, sticky="w", padx=5, pady=5)
         lang_container = tk.Frame(settings_frame)
-        lang_container.grid(row=2, column=1, sticky="w", padx=5, pady=5, columnspan=2)
+        lang_container.grid(row=3, column=1, sticky="w", padx=5, pady=5, columnspan=2)
 
         self.language_entry = tk.Entry(lang_container, textvariable=self.language_var, width=20, font=("Arial", 10))
         self.language_entry.pack(side="top", anchor="w")
 
         tk.Label(lang_container, text="(Use \"auto\" for auto-detection)", font=("Arial", 8)).pack(side="top", anchor="w")
 
-        # Row 3: Beam Size
-        tk.Label(settings_frame, text="Beam Size:", font=("Arial", 10)).grid(row=3, column=0, sticky="w", padx=5, pady=5)
+        # Row 4: Beam Size
+        tk.Label(settings_frame, text="Beam Size:", font=("Arial", 10)).grid(row=4, column=0, sticky="w", padx=5, pady=5)
         self.beam_size_spinbox = tk.Spinbox(settings_frame, from_=1, to=10, textvariable=self.beam_size_var,
                                             width=5, font=("Arial", 10))
-        self.beam_size_spinbox.grid(row=3, column=1, sticky="w", padx=5, pady=5)
+        self.beam_size_spinbox.grid(row=4, column=1, sticky="w", padx=5, pady=5)
 
-        # Row 4: Start Time
-        tk.Label(settings_frame, text="Start Time [hh:mm:ss]:", font=("Arial", 10)).grid(row=4, column=0, sticky="w", padx=5, pady=5)
+        # Row 5: Start Time
+        tk.Label(settings_frame, text="Start Time [hh:mm:ss]:", font=("Arial", 10)).grid(row=5, column=0, sticky="w", padx=5, pady=5)
         self.start_time_entry = tk.Entry(settings_frame, textvariable=self.start_time_var, width=10, font=("Arial", 10))
-        self.start_time_entry.grid(row=4, column=1, sticky="w", padx=5, pady=5)
+        self.start_time_entry.grid(row=5, column=1, sticky="w", padx=5, pady=5)
 
-        # Row 5: End Time
-        tk.Label(settings_frame, text="End Time [hh:mm:ss]:", font=("Arial", 10)).grid(row=5, column=0, sticky="w", padx=5, pady=5)
+        # Row 6: End Time
+        tk.Label(settings_frame, text="End Time [hh:mm:ss]:", font=("Arial", 10)).grid(row=6, column=0, sticky="w", padx=5, pady=5)
         endtime_container = tk.Frame(settings_frame)
-        endtime_container.grid(row=5, column=1, sticky="w", padx=5, pady=5, columnspan=2)
+        endtime_container.grid(row=6, column=1, sticky="w", padx=5, pady=5, columnspan=2)
 
         self.end_time_entry = tk.Entry(endtime_container, textvariable=self.end_time_var, width=10, font=("Arial", 10))
         self.end_time_entry.pack(side="top", anchor="w")
 
         tk.Label(endtime_container, text="(Leave empty for full duration)", font=("Arial", 8)).pack(side="top", anchor="w")
 
-        # Row 6: Generate SRT Subtitles Checkbox
+        # Row 7: Generate SRT Subtitles Checkbox
         self.srt_checkbox = tk.Checkbutton(settings_frame, text="Generate SRT Subtitles", variable=self.srt_var, anchor="w")
-        self.srt_checkbox.grid(row=6, column=1, sticky="w", padx=5, pady=2)
+        self.srt_checkbox.grid(row=7, column=1, sticky="w", padx=5, pady=2)
 
-        # Row 7: Enable Diarization Checkbox
+        # Row 8: Enable Diarization Checkbox
         self.diarization_option = DiarizationOption(settings_frame)
-        self.diarization_option.checkbox.grid(row=7, column=1, sticky="w", padx=5, pady=2)
+        self.diarization_option.checkbox.grid(row=8, column=1, sticky="w", padx=5, pady=2)
 
-        # Row 8: Whisper.cpp Executable
-        tk.Label(settings_frame, text="Whisper.cpp Executable:", font=("Arial", 10)).grid(row=8, column=0, sticky="w", padx=5, pady=5)
+        # Row 9: Whisper.cpp Executable
+        tk.Label(settings_frame, text="Whisper.cpp Executable:", font=("Arial", 10)).grid(row=9, column=0, sticky="w", padx=5, pady=5)
         self.whisper_location_entry = tk.Entry(settings_frame, textvariable=self.WHISPER_CPP_PATH, width=40, font=("Arial", 10))
-        self.whisper_location_entry.grid(row=8, column=1, sticky="w", padx=5, pady=5)
+        self.whisper_location_entry.grid(row=9, column=1, sticky="w", padx=5, pady=5)
         self.whisper_browse_button = tk.Button(settings_frame, text="Browse", command=self.browse_whisper_executable, font=("Arial", 10))
-        self.whisper_browse_button.grid(row=8, column=2, sticky="w", padx=5, pady=5)
+        self.whisper_browse_button.grid(row=9, column=2, sticky="w", padx=5, pady=5)
+
+        # Row 10: TwelveLabs API key (used only by the Pegasus engine)
+        tk.Label(settings_frame, text="TwelveLabs API Key:", font=("Arial", 10)).grid(row=10, column=0, sticky="w", padx=5, pady=5)
+        self.twelvelabs_key_entry = tk.Entry(settings_frame, textvariable=self.twelvelabs_api_key_var,
+                                             width=40, show="*", font=("Arial", 10))
+        self.twelvelabs_key_entry.grid(row=10, column=1, sticky="w", padx=5, pady=5)
+        tk.Label(settings_frame, text="(or set TWELVELABS_API_KEY env var)", font=("Arial", 8)).grid(
+            row=11, column=1, sticky="w", padx=5)
 
         # ---------------------------
         # Transcription Frame
@@ -602,6 +632,8 @@ class SoftWhisper:
                 self.beam_size_var.set(config.get('beam_size', 5))
                 # Restore Whisper path
                 self.WHISPER_CPP_PATH.set(config.get('WHISPER_CPP_PATH', get_default_whisper_cpp_path()))
+                # Restore transcription engine (default: local Whisper.cpp)
+                self.engine_var.set(config.get('engine', 'whisper.cpp'))
                 # Restore last‑opened folder (fallback to already-set self.last_dir)
                 self.last_dir = config.get('last_dir', self.last_dir)
                 debug_print(f"Configuration loaded: {config}")
@@ -614,7 +646,8 @@ class SoftWhisper:
         config = {
             'beam_size': self.beam_size_var.get(),
             'WHISPER_CPP_PATH': self.WHISPER_CPP_PATH.get(),
-            'last_dir': self.last_dir
+            'last_dir': self.last_dir,
+            'engine': self.engine_var.get()
         }
         try:
             with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
@@ -630,6 +663,12 @@ class SoftWhisper:
 
     def load_model(self):
         debug_print("Entering load_model()")
+        # The TwelveLabs Pegasus engine is cloud-based; no local model file.
+        if self.engine_var.get() == "twelvelabs-pegasus":
+            self.model_loaded = True
+            self.progress_queue.put((100, "TwelveLabs Pegasus engine ready (cloud)"))
+            self.root.after(0, self.enable_buttons)
+            return
         selected_model = self.model_var.get()
         try:
             self.progress_queue.put((0, f"Checking model '{selected_model}'..."))
@@ -647,6 +686,22 @@ class SoftWhisper:
             self.model_var.set(self.previous_model if hasattr(self, 'previous_model') else "base")
             self.root.after(0, self.enable_buttons)
             debug_print("load_model() encountered an error.")
+
+    def on_engine_change(self, event):
+        debug_print(f"Engine change requested: {self.engine_var.get()}")
+        self.save_config()
+        if self.engine_var.get() == "twelvelabs-pegasus":
+            # Cloud engine needs no local model file; allow starting immediately.
+            self.model_loaded = True
+            self.update_status("TwelveLabs Pegasus engine selected (cloud).", "blue")
+            self.root.after(0, self.enable_buttons)
+        else:
+            # Switching back to local Whisper.cpp: re-check the model file.
+            self.model_loaded = False
+            self.update_status("Checking selected Whisper.cpp model...", "blue")
+            self.disable_buttons()
+            self.model_loading_thread = threading.Thread(target=self.load_model, daemon=True)
+            self.model_loading_thread.start()
 
     def on_model_change(self, event):
         debug_print("Model change requested")
@@ -746,6 +801,7 @@ class SoftWhisper:
             debug_print(f"Language setting: '{lang}'")
 
             options = {
+                'engine': self.engine_var.get(),
                 'model_name': self.model_var.get(),
                 'task': self.task_var.get(),
                 'language': lang,
@@ -754,24 +810,28 @@ class SoftWhisper:
                 'end_time': self.end_time_var.get().strip(),
                 'generate_srt': self.srt_var.get(),
                 'parent_window': self.root,
-                'whisper_executable': self.WHISPER_CPP_PATH.get()
+                'whisper_executable': self.WHISPER_CPP_PATH.get(),
+                'twelvelabs_api_key': self.twelvelabs_api_key_var.get().strip(),
             }
-
-            # Resolve executable path
-            executable_abs = self._resolve_whisper_executable(options['whisper_executable'])
-            options['whisper_executable'] = executable_abs
-            debug_print(f"Using Whisper executable: {executable_abs}")
 
             # Absolute path for the input file
             file_path = os.path.abspath(file_path)
 
-            # Build a rough command template for debugging purposes
-            model_abs = os.path.abspath(os.path.join("models", "whisper", f"ggml-{options['model_name']}.bin"))
-            whisper_cmd = f"{executable_abs} -m {model_abs} -f {file_path} -l {options['language']} -bs {options['beam_size']}"
-            if options['task'] == 'translate':
-                whisper_cmd += " -translate"
-            whisper_cmd += " -oj"
-            debug_print(f"Command template: {whisper_cmd}")
+            # Whisper.cpp-only setup. The TwelveLabs Pegasus engine is
+            # cloud-based and needs no local executable, so skip it.
+            if options['engine'] != 'twelvelabs-pegasus':
+                # Resolve executable path
+                executable_abs = self._resolve_whisper_executable(options['whisper_executable'])
+                options['whisper_executable'] = executable_abs
+                debug_print(f"Using Whisper executable: {executable_abs}")
+
+                # Build a rough command template for debugging purposes
+                model_abs = os.path.abspath(os.path.join("models", "whisper", f"ggml-{options['model_name']}.bin"))
+                whisper_cmd = f"{executable_abs} -m {model_abs} -f {file_path} -l {options['language']} -bs {options['beam_size']}"
+                if options['task'] == 'translate':
+                    whisper_cmd += " -translate"
+                whisper_cmd += " -oj"
+                debug_print(f"Command template: {whisper_cmd}")
 
             # Define callbacks for progress and status updates
             def progress_callback(progress, message):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pyannote.audio
 librosa
 opencv-python
 tensorflow
+twelvelabs>=1.2.8

--- a/test_twelvelabs_backend.py
+++ b/test_twelvelabs_backend.py
@@ -1,0 +1,86 @@
+"""
+Tests for the optional TwelveLabs Pegasus transcription backend.
+
+Run with:
+    python -m unittest test_twelvelabs_backend
+
+The parsing tests run offline and always execute. The live smoke test only
+runs when TWELVELABS_API_KEY is set and the `twelvelabs` package is installed;
+it is skipped otherwise so CI without a key still passes.
+"""
+
+import os
+import unittest
+
+import twelvelabs_backend as tlb
+
+
+class TestParsing(unittest.TestCase):
+    """No-network tests for the output parsers and result shape."""
+
+    def test_parse_ts_variants(self):
+        self.assertAlmostEqual(tlb._parse_ts("00:00:01.500"), 1.5)
+        self.assertAlmostEqual(tlb._parse_ts("01:02"), 62.0)
+        self.assertAlmostEqual(tlb._parse_ts("00:01:02"), 62.0)
+        self.assertAlmostEqual(tlb._parse_ts("5"), 5.0)
+        self.assertIsNone(tlb._parse_ts(""))
+        self.assertIsNone(tlb._parse_ts("not-a-time"))
+
+    def test_segments_from_bracketed_text(self):
+        raw = (
+            "[00:00:00.000 --> 00:00:02.500] Hello there.\n"
+            "[00:00:02.500 --> 00:00:05.000] How are you?"
+        )
+        segs = tlb._segments_from_pegasus_text(raw)
+        self.assertEqual(len(segs), 2)
+        self.assertEqual(segs[0]["text"], "Hello there.")
+        self.assertAlmostEqual(segs[0]["start"], 0.0)
+        self.assertAlmostEqual(segs[0]["end"], 2.5)
+        self.assertEqual(segs[1]["text"], "How are you?")
+
+    def test_segments_keeps_untimestamped_lines(self):
+        segs = tlb._segments_from_pegasus_text("Just a paragraph with no times.")
+        self.assertEqual(len(segs), 1)
+        self.assertIsNone(segs[0]["start"])
+        self.assertEqual(segs[0]["text"], "Just a paragraph with no times.")
+
+    def test_normalize_raw_passthrough_and_paragraph(self):
+        bracketed = "[00:00:00.000 --> 00:00:01.000] Hi"
+        self.assertEqual(tlb._normalize_raw(bracketed), bracketed)
+        self.assertEqual(tlb._normalize_raw("  a paragraph  "), "a paragraph")
+        self.assertEqual(tlb._normalize_raw(""), "")
+
+    def test_resolve_api_key_missing_raises(self):
+        saved = os.environ.pop("TWELVELABS_API_KEY", None)
+        try:
+            with self.assertRaises(RuntimeError):
+                tlb._resolve_api_key({})
+            self.assertEqual(tlb._resolve_api_key({"twelvelabs_api_key": "abc"}), "abc")
+        finally:
+            if saved is not None:
+                os.environ["TWELVELABS_API_KEY"] = saved
+
+    def test_result_shape_matches_whisper_contract(self):
+        r = tlb._result("raw", "text", [], 1.0, "", False)
+        self.assertEqual(
+            set(r.keys()),
+            {"raw", "text", "segments", "audio_length", "stderr", "cancelled"},
+        )
+
+
+@unittest.skipUnless(
+    os.environ.get("TWELVELABS_API_KEY"), "TWELVELABS_API_KEY not set"
+)
+class TestLiveSmoke(unittest.TestCase):
+    """Live wiring check against the TwelveLabs API (requires a key)."""
+
+    def test_client_constructs_and_analyze_is_callable(self):
+        from twelvelabs import TwelveLabs
+
+        client = TwelveLabs(api_key=os.environ["TWELVELABS_API_KEY"])
+        self.assertTrue(callable(client.analyze))
+        self.assertTrue(hasattr(client, "assets"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twelvelabs_backend.py
+++ b/twelvelabs_backend.py
@@ -1,0 +1,234 @@
+"""
+Optional TwelveLabs Pegasus transcription backend for SoftWhisper.
+
+This is an opt-in alternative to the default local Whisper.cpp engine. When the
+user selects the "TwelveLabs (Pegasus)" engine, transcription is performed by
+the TwelveLabs Pegasus video-understanding model in the cloud instead of by the
+local whisper-cli executable.
+
+It returns the exact same result dictionary shape as transcribe_audio() in
+SoftWhisper.py, so the rest of the application (SRT export, diarization,
+display) works unchanged:
+
+    {
+        'raw':          <whisper.cpp-style bracketed text>,
+        'text':         <plain transcript>,
+        'segments':     [{'text', 'start', 'end'} ...],
+        'audio_length': <seconds>,
+        'stderr':       <diagnostic string>,
+        'cancelled':    <bool>,
+    }
+
+Requires the `twelvelabs` package (see requirements.txt) and an API key, read
+from the TWELVELABS_API_KEY environment variable or passed via options. Grab a
+free key at https://twelvelabs.io.
+"""
+
+import os
+import time
+
+# Default Pegasus model. 'pegasus1.5' is the current general-analysis model.
+DEFAULT_PEGASUS_MODEL = "pegasus1.5"
+
+# Prompt that asks Pegasus to return a verbatim, timestamped transcript.
+_TRANSCRIBE_PROMPT = (
+    "Transcribe all spoken words in this video verbatim. Output one line per "
+    "spoken segment in exactly this format, with no extra commentary:\n"
+    "[HH:MM:SS.mmm --> HH:MM:SS.mmm] text\n"
+    "Use punctuation. Do not censor any words. Do not describe visuals."
+)
+
+_TRANSLATE_PROMPT = (
+    "Transcribe all spoken words in this video and translate them into English. "
+    "Output one line per spoken segment in exactly this format, with no extra "
+    "commentary:\n"
+    "[HH:MM:SS.mmm --> HH:MM:SS.mmm] text\n"
+    "Use punctuation. Do not censor any words. Do not describe visuals."
+)
+
+# How long to wait for a freshly uploaded asset to finish server-side
+# processing before giving up (seconds).
+_ASSET_READY_TIMEOUT = 600
+
+
+def _resolve_api_key(options):
+    """Return the API key from options or the environment, or raise."""
+    key = (options or {}).get("twelvelabs_api_key") or os.environ.get("TWELVELABS_API_KEY")
+    if not key:
+        raise RuntimeError(
+            "TwelveLabs API key not found. Set the TWELVELABS_API_KEY environment "
+            "variable or enter a key in the settings. Get a free key at "
+            "https://twelvelabs.io."
+        )
+    return key
+
+
+def _parse_ts(text):
+    """Parse 'HH:MM:SS.mmm' (or MM:SS / SS) into seconds, or None."""
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        parts = text.split(":")
+        if len(parts) == 3:
+            h, m, s = parts
+            return int(h) * 3600 + int(m) * 60 + float(s)
+        if len(parts) == 2:
+            m, s = parts
+            return int(m) * 60 + float(s)
+        return float(parts[0])
+    except (ValueError, TypeError):
+        return None
+
+
+def _segments_from_pegasus_text(raw):
+    """Turn Pegasus' bracketed output into a list of segment dicts.
+
+    Mirrors the {'text', 'start', 'end'} shape SoftWhisper already builds from
+    whisper.cpp JSON. Lines Pegasus emits without a recognizable timestamp are
+    kept as text-only segments so nothing is silently dropped.
+    """
+    import re
+
+    segments = []
+    line_re = re.compile(
+        r"^\[(\d{1,2}:\d{2}:\d{2}(?:\.\d+)?)\s*-->\s*(\d{1,2}:\d{2}:\d{2}(?:\.\d+)?)\]\s*(.*)$"
+    )
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        m = line_re.match(line)
+        if m:
+            start, end, text = m.groups()
+            segments.append(
+                {"text": text.strip(), "start": _parse_ts(start), "end": _parse_ts(end)}
+            )
+        else:
+            segments.append({"text": line, "start": None, "end": None})
+    return segments
+
+
+def _normalize_raw(data):
+    """Ensure the model output is bracketed line-per-segment text.
+
+    If Pegasus already returned the requested '[start --> end] text' format we
+    pass it through; otherwise we emit a single bracket-less line so downstream
+    plain-text display still works.
+    """
+    text = (data or "").strip()
+    if not text:
+        return ""
+    if "-->" in text:
+        return text
+    # Model returned a paragraph; keep it as one untimestamped line.
+    return text
+
+
+def transcribe_with_pegasus(
+    file_path,
+    options,
+    progress_callback=None,
+    status_callback=None,
+    stop_event=None,
+):
+    """Transcribe a media file with TwelveLabs Pegasus.
+
+    Drop-in replacement for SoftWhisper.transcribe_audio() with the same
+    signature and return shape. Network/cloud based and opt-in.
+    """
+    from twelvelabs import TwelveLabs
+    from twelvelabs.types.video_context import VideoContext_AssetId
+
+    file_path = os.path.abspath(file_path)
+    options = options or {}
+    api_key = _resolve_api_key(options)
+    model_name = options.get("pegasus_model", DEFAULT_PEGASUS_MODEL)
+    task = options.get("task", "transcribe")
+    max_tokens = int(options.get("max_tokens", 2048))
+
+    def _cancelled():
+        return bool(stop_event and stop_event.is_set())
+
+    def _status(msg, color="blue"):
+        if status_callback:
+            status_callback(msg, color)
+
+    client = TwelveLabs(api_key=api_key)
+
+    # 1) Upload the local file as an asset.
+    if progress_callback:
+        progress_callback(5, "Uploading to TwelveLabs...")
+    _status("Uploading media to TwelveLabs...", "blue")
+    with open(file_path, "rb") as fh:
+        asset = client.assets.create(
+            method="direct", file=fh, filename=os.path.basename(file_path)
+        )
+
+    if _cancelled():
+        return _result("", "", [], 0.0, "Cancelled before analysis.", True)
+
+    # 2) Wait for server-side processing to complete.
+    deadline = time.time() + _ASSET_READY_TIMEOUT
+    status = getattr(asset, "status", None)
+    while status == "processing":
+        if _cancelled():
+            return _result("", "", [], 0.0, "Cancelled while uploading.", True)
+        if time.time() > deadline:
+            raise RuntimeError("TwelveLabs asset processing timed out.")
+        if progress_callback:
+            progress_callback(15, "Processing upload...")
+        time.sleep(3)
+        asset = client.assets.retrieve(asset.id)
+        status = getattr(asset, "status", None)
+    if status == "failed":
+        raise RuntimeError("TwelveLabs failed to process the uploaded file.")
+
+    audio_length = float(getattr(asset, "duration", 0.0) or 0.0)
+
+    # 3) Run Pegasus analysis. start/end mirror whisper.cpp trimming.
+    if progress_callback:
+        progress_callback(40, "Analyzing with Pegasus...")
+    _status(f"Analyzing with Pegasus ({model_name})...", "blue")
+
+    prompt = _TRANSLATE_PROMPT if task == "translate" else _TRANSCRIBE_PROMPT
+    analyze_kwargs = {
+        "model_name": model_name,
+        "video": VideoContext_AssetId(asset_id=asset.id),
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+    }
+    start_sec = _parse_ts(options.get("start_time", ""))
+    end_sec = _parse_ts(options.get("end_time", ""))
+    if start_sec:
+        analyze_kwargs["start_time"] = start_sec
+    if end_sec:
+        analyze_kwargs["end_time"] = end_sec
+
+    response = client.analyze(**analyze_kwargs)
+
+    if progress_callback:
+        progress_callback(95, "Formatting transcript...")
+
+    if _cancelled():
+        return _result("", "", [], audio_length, "Cancelled after analysis.", True)
+
+    raw = _normalize_raw(getattr(response, "data", "") or "")
+    segments = _segments_from_pegasus_text(raw)
+    plain_text = " ".join(seg["text"] for seg in segments if seg.get("text")).strip()
+
+    if progress_callback:
+        progress_callback(100, "Transcribing: 100%")
+
+    return _result(raw, plain_text, segments, audio_length, "", False)
+
+
+def _result(raw, text, segments, audio_length, stderr, cancelled):
+    return {
+        "raw": raw,
+        "text": text,
+        "segments": segments,
+        "audio_length": audio_length,
+        "stderr": stderr,
+        "cancelled": cancelled,
+    }


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds an **opt-in** cloud transcription engine powered by the [TwelveLabs Pegasus](https://twelvelabs.io) video-understanding model, alongside the existing local Whisper.cpp engine.

### What it adds
- A new **Engine** dropdown in *Optional Settings* with two choices: `whisper.cpp` (default) and `twelvelabs-pegasus`.
- A small `twelvelabs_backend.py` module that uploads the selected media as a TwelveLabs asset, runs Pegasus analysis, and returns **the exact same result dict shape** as `transcribe_audio()` (`raw` / `text` / `segments` / `audio_length` / `stderr` / `cancelled`). Because of this, SRT export, diarization, and the transcript display all work unchanged.
- A TwelveLabs API key field (also read from the `TWELVELABS_API_KEY` environment variable), persisted in `config.json` like the other settings.

### Why it helps
Whisper.cpp is great for local, offline transcription. Pegasus gives users an optional cloud path that handles long videos and runs without needing a local model or GPU — useful when the machine can't run the larger Whisper models comfortably.

### Opt-in / non-breaking
The default engine stays `whisper.cpp` and that code path is untouched. The TwelveLabs code only runs when a user explicitly selects the new engine. The dependency (`twelvelabs>=1.2.8`) is only imported lazily inside the backend, so existing installs are unaffected until they opt in.

### How it was tested
- `python -m unittest test_twelvelabs_backend` — offline unit tests for the timestamp/segment parsers, result-shape contract, and API-key resolution (added in this PR; they run without a key).
- A live smoke test (gated on `TWELVELABS_API_KEY`, skipped otherwise) confirming the client constructs and the analyze/assets API is wired correctly.
- Verified against the real API with my key: client authenticates and a TwelveLabs embedding call returns a 512-dim vector. The Pegasus request wiring is verified against the installed SDK (asset upload + `VideoContext_AssetId` + `analyze`); a full end-to-end Pegasus run is slow due to server-side video processing.
- `py_compile` on all changed files.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.